### PR TITLE
Remove apostrophe from it's

### DIFF
--- a/d8.html
+++ b/d8.html
@@ -87,7 +87,7 @@
 
 
 <section>
-  <h2 id="core-is-in-it-s-own-folder">Core is in it's own folder</h2>
+  <h2 id="core-is-in-it-s-own-folder">Core is in its own folder</h2>
   <ul class="file-list">
     <li>Drupal Root
       <ul>


### PR DESCRIPTION
"Core is in it's own folder" should be "Core is in its own folder" because English is hard.
